### PR TITLE
Debug bdlim1

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,0 +1,34 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+name: R-CMD-check
+
+permissions: read-all
+
+jobs:
+  R-CMD-check:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck
+          needs: check
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true
+          build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'

--- a/R/bdlim1.R
+++ b/R/bdlim1.R
@@ -25,15 +25,21 @@
 bdlim1 <- function(y, exposure, covars, group, id=NULL, w_free, b_free, df, nits, nburn=round(nits/2), nthin=1){
 
   # make sure group is a factor variable
-  if(!is.factor(group)){
+  if (!is.factor(group)) {
     stop("group must be a factor variable.")
   }
 
-  # make sure covariates have names
-  if(is.null(colnames(covars))){
-    covars <- as.data.frame(covars)
-    colnames(covars) <- paste0("covar",1:ncol(covars))
+  # make sure exposure is a data.frame
+  exposure <- as.data.frame(exposure)
+  if (is.null(colnames(exposure))) {
+    colnames(exposure) <- paste0("exposure", 1:ncol(exposure))
   }
+
+  # make sure covariates have names
+  if (is.null(colnames(covars))) {
+    colnames(covars) <- paste0("covar", 1:ncol(covars))
+  }
+  covars <- as.data.frame(covars)
 
   # make design matrix for all data except exposures
   # sort by group to make help with MCMC.
@@ -42,6 +48,10 @@ bdlim1 <- function(y, exposure, covars, group, id=NULL, w_free, b_free, df, nits
   alldata <- droplevels(drop_na(cbind(y,group,covars,exposure)), group)
   if(length(y)<nrow(alldata)){
     warning("Dropped",length(y)-nrow(alldata),"observations with missing values.")
+  }
+
+  if(length(levels(group)) != length(levels(alldata$group))) {
+    warning("Removing rows with missing values removed a level in the group")
   }
 
   # ADD random effect matrix here
@@ -72,10 +82,11 @@ bdlim1 <- function(y, exposure, covars, group, id=NULL, w_free, b_free, df, nits
 
   # basis for weights
   basis <- makebasis(exposure,df=df)
+  n_times <- nrow(basis) # or ncol(exposure)
 
   # preliminary weighted exposures
   # make flat for all groups
-  theta <- lm(rep(1/sqrt(37),37)~basis-1)$coef
+  theta <- lm(rep(1/sqrt(n_times),n_times)~basis-1)$coef
   w <- drop(basis%*%theta)
   w <- w / sqrt(sum(w^2))
   w <- w * sign(sum(w))
@@ -83,7 +94,6 @@ bdlim1 <- function(y, exposure, covars, group, id=NULL, w_free, b_free, df, nits
   # starting values for weighted exposures
   # these are the same weightings for all groups
   E <- exposure %*% w
-
 
   # replicate if w is group specific
   if(w_free){
@@ -108,7 +118,6 @@ bdlim1 <- function(y, exposure, covars, group, id=NULL, w_free, b_free, df, nits
   # add weighted exposures to design matrix.
   design <- cbind(design,Edesign*drop(E))
   n_regcoef <- ncol(design)
-
 
   # index for groups for weights
   # identifies which rows are in which weight groups

--- a/R/bdlim1.R
+++ b/R/bdlim1.R
@@ -46,8 +46,8 @@ bdlim1 <- function(y, exposure, covars, group, id=NULL, w_free, b_free, df, nits
   # remove observations with missing values
   # drop unused levels
   alldata <- droplevels(drop_na(cbind(y,group,covars,exposure)), group)
-  if(length(y)<nrow(alldata)){
-    warning("Dropped",length(y)-nrow(alldata),"observations with missing values.")
+  if(length(y)>nrow(alldata)){
+    warning("Dropped ",length(y)-nrow(alldata)," observations with missing values.", call.=FALSE)
   }
 
   if(length(levels(group)) != length(levels(alldata$group))) {
@@ -79,6 +79,9 @@ bdlim1 <- function(y, exposure, covars, group, id=NULL, w_free, b_free, df, nits
 
   # exposure matrix
   exposure <- mm[,c(ncol(mm)+1-c(ncol(exposure):1))]
+
+  # outcome with na removed
+  y <- alldata[,"y"]
 
   # basis for weights
   basis <- makebasis(exposure,df=df)

--- a/R/data.R
+++ b/R/data.R
@@ -1,6 +1,6 @@
 #' Simulated Birth Data
 #'
-#' A dataset containing simulated birth data for examples with bdlim. Add outcome and covariate data is simulated. The exposure data is real exposure data. Therefore, it has realistic correlation structure. The exposures are consistent with the date of conception variables.
+#' A dataset containing simulated birth data for examples with bdlim. Add outcome and covariate data is simulated. The exposure data is real exposure data. Therefore, it has realistic correlation structure. The exposures are consistent with the date of conception variables. Each exposure is scaled by its IQR.
 #'
 #' @format A data frame with 1000 rows (observations) and 202 variables:
 #' \describe{

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # bdlim <img src="man/figures/logo.png" align="right" />
 
 [![CRAN status](https://www.r-pkg.org/badges/version/bdlim)](https://CRAN.R-project.org/package=bdlim)
+[![Downloads](https://cranlogs.r-pkg.org/badges/bdlim)](https://cran.rstudio.com/package=bdlim)
 
 
 ### Overview

--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
+
+# bdlim
+
+
+
 # bdlim <img src="man/figures/logo.png" align="right" />
 
+<!-- badges: start -->
+[![R-CMD-check](https://github.com/AnderWilson/bdlim/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/AnderWilson/bdlim/actions/workflows/R-CMD-check.yaml)
 [![CRAN status](https://www.r-pkg.org/badges/version/bdlim)](https://CRAN.R-project.org/package=bdlim)
 [![Downloads](https://cranlogs.r-pkg.org/badges/bdlim)](https://cran.rstudio.com/package=bdlim)
-
+<!-- badges: end -->
 
 ### Overview
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,4 @@
-
-# bdlim
-
-
-
-# bdlim <img src="man/figures/logo.png" align="right" />
+# bdlim <a href="https://anderwilson.github.io/bdlim/"><img src="man/figures/logo.png" align="right" height="138" /></a>
 
 <!-- badges: start -->
 [![R-CMD-check](https://github.com/AnderWilson/bdlim/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/AnderWilson/bdlim/actions/workflows/R-CMD-check.yaml)

--- a/man/sbd_bdlim.Rd
+++ b/man/sbd_bdlim.Rd
@@ -215,6 +215,6 @@ A data frame with 1000 rows (observations) and 202 variables:
 sbd_bdlim
 }
 \description{
-A dataset containing simulated birth data for examples with bdlim. Add outcome and covariate data is simulated. The exposure data is real exposure data. Therefore, it has realistic correlation structure. The exposures are consistent with the date of conception variables.
+A dataset containing simulated birth data for examples with bdlim. Add outcome and covariate data is simulated. The exposure data is real exposure data. Therefore, it has realistic correlation structure. The exposures are consistent with the date of conception variables. Each exposure is scaled by its IQR.
 }
 \keyword{datasets}


### PR DESCRIPTION
Fix 2 bugs in in R/bdlim1.R:

1) if covars is a named matrix and exposure is a matrix (as suggested in the help file), then `drop_na` will fail because `cbind` will create a matrix, and `drop_na` doesn't have a matrix method. Also, when converted to a matrix, this will convert the factor `group` into a numeric variable, causing levels of `group` to be dropped, making `names_groups <- levels(alldata$group)` return NULL to `names_group` which would be incorrect.

REPREX:
```r
# Convert covars to a matrix
named_Z <- as.matrix(sbd_bdlim[,c("MomPriorBMI")])
# Named matrix to skip the `if(is.null(colnames(covars)))` check
colnames(named_Z) <- "MomPriorBMI"

# X can be entered as a matrix as suggested in the docs
matrix_X <- as.matrix(sbd_bdlim[,paste0("pm25_",1:37)])

# Error because cbind(y,group,covars,exposure) returns a matrix and drop_na don't have a matrix method
fit_sex <- bdlim4(
  y = sbd_bdlim$bwgaz,
  exposure = matrix_X,
  covars = named_Z,
  group = as.factor(sbd_bdlim$ChildSex),
  df = 5,
  nits = 100,
  parallel = FALSE
)

```

2) Hardcoded numbers of times the exposure measured to be 37 in line 78:
  theta <- lm(rep(1/sqrt(37),37)~basis-1)$coef

REPREX:
```r
# 37 is hardcoded
fit_sex <- bdlim4(
  y = sbd_bdlim$bwgaz,
  exposure = sbd_bdlim[,paste0("pm25_",1:36)],
  covars = sbd_bdlim[,c("MomPriorBMI","MomAge","race","Hispanic",
                                   "EstMonthConcept","EstYearConcept")],
  group = as.factor(sbd_bdlim$ChildSex),
  df = 5,
  nits = 100,
  parallel = FALSE
)
```


